### PR TITLE
Feature/custom required validator

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+### New features
+- Added option for custom **required validators**. The form will now recognize a custom required validator if a synchronous validator is tagged with `isDefaultValidator = true`
+
 ## [2.0.0] # 2018-11-19
 ### Breaking changes
 **Changed default usage of form fields**

--- a/src/components/withValidation/ValidationWrapper/ValidationWrapper.test.tsx
+++ b/src/components/withValidation/ValidationWrapper/ValidationWrapper.test.tsx
@@ -140,21 +140,47 @@ describe('withValidation', () => {
     });
 
     describe('required validator', () => {
-      it('should set validation.isRequired to false if there is no required validator present', () => {
-        const { validation } = setup();
-        expect(validation.isRequired).toBeFalsy();
-      });
+      const createValidator = (defaultValue: unknown): Function => {
+        const customRequiredValidator = (): undefined => undefined;
+        customRequiredValidator.isDefaultValidator = defaultValue;
 
-      it('should set validation.isRequired to true if there is a required validatior present', () => {
-        const validators = [
-          defaultValidators.required,
-        ];
+        return customRequiredValidator;
+      };
 
+      const cases = [
+        [
+          'should set validation.isRequired to false if there is no required validator present',
+          undefined,
+          false,
+        ],
+        [
+          'should set validation.isRequired to true if the default validator is present',
+          [ defaultValidators.required ],
+          true,
+        ],
+        [
+          'should set validation.isRequired to true if a validator with isDefaultValidator=true is present',
+          [ createValidator(true) ],
+          true,
+        ],
+        [
+          'should set validation.isRequired to false if a validator with isDefaultValidator=false is present',
+          [ createValidator(false) ],
+          false,
+        ],
+        [
+          'should set validation.isRequired to false if a validator with isDefaultValidator="foobar" is present',
+          [ createValidator('foobar') ],
+          false,
+        ],
+      ];
+
+      it.each(cases)('%s', (name, validators, expectedIsRequiredState) => {
         const { validation } = setup({ props: {
           validators,
         }});
 
-        expect(validation.isRequired).toBeTruthy();
+        expect(validation.isRequired).toEqual(expectedIsRequiredState);
       });
     });
   });

--- a/src/components/withValidation/ValidationWrapper/ValidationWrapper.test.tsx
+++ b/src/components/withValidation/ValidationWrapper/ValidationWrapper.test.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
 
 import { createMockFormContext } from '../../../test-utils/enzymeFormContext';
-import { validators as defaultValidators } from '../../../validators';
+import { TValidator, validators as defaultValidators } from '../../../validators';
 import { IFormContext } from '../../FormContext';
 import { IValidationProp, IValidationState, IValidationWrapperProps } from '../withValidation.types';
 import { BaseValidationWrapper } from './ValidationWrapper';
@@ -175,7 +175,7 @@ describe('withValidation', () => {
         ],
       ];
 
-      it.each(cases)('%s', (name, validators, expectedIsRequiredState) => {
+      it.each(cases)('%s', (name: string, validators: undefined | TValidator[], expectedIsRequiredState: unknown) => {
         const { validation } = setup({ props: {
           validators,
         }});

--- a/src/components/withValidation/ValidationWrapper/ValidationWrapper.tsx
+++ b/src/components/withValidation/ValidationWrapper/ValidationWrapper.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { parseValidationError } from '../../../utils';
-import { isIFieldErrorObject, validators as defaultValidators } from '../../../validators';
+import { isDefaultValidator, isIFieldErrorObject } from '../../../validators';
 import { TBasicFieldValue } from '../../withField';
 import { withForm } from '../../withForm';
 import { IValidationArgs, IValidationState, IValidationWrapperProps } from '../withValidation.types';
@@ -66,7 +66,7 @@ export class BaseValidationWrapper extends React.Component<IValidationWrapperPro
   private checkIsRequired = (): boolean => {
     const { validators } = this.props;
 
-    return Array.isArray(validators) && validators.includes(defaultValidators.required);
+    return Array.isArray(validators) && validators.some(isDefaultValidator);
   }
 
   /**

--- a/src/validators/validators.ts
+++ b/src/validators/validators.ts
@@ -98,8 +98,7 @@ interface ILength {
 
 // tslint:disable-next-line:no-any
 function isILength(object: any): object is ILength {
-  // tslint:disable-next-line:no-unsafe-any
-  return object !== null && object !== undefined && typeof object.length === 'number';
+  return object !== null && object !== undefined && typeof (<ILength>object).length === 'number';
 }
 
 // tslint:disable-next-line:naming-convention

--- a/src/validators/validators.ts
+++ b/src/validators/validators.ts
@@ -43,6 +43,7 @@ const required = (value: TBasicFieldValue): TFieldError => {
 
   return value !== null && value !== undefined ? undefined : FieldErrorMessageId.Required;
 };
+required.isDefaultValidator = true;
 
 /**
  * Checks if the value is alpha numeric

--- a/src/validators/validators.types.ts
+++ b/src/validators/validators.types.ts
@@ -63,3 +63,19 @@ export type TValidator = ((value: TBasicFieldValue | undefined, context: IFormCo
  * Async validator method type
  */
 export type TAsyncValidator = ((value: TBasicFieldValue | undefined, context: IFormContext, ...args: unknown[]) => Promise<TFieldError>);
+
+/**
+ * Default validator type
+ */
+export interface IDefaultValidator extends TValidator {
+  isDefaultValidator: true;
+}
+
+/**
+ * Returns true if the given object is a IDefaultValidator
+ * @param object Function to test
+ */
+// tslint:disable-next-line:no-any
+export function isDefaultValidator(object: any): object is IDefaultValidator {
+  return object && typeof object === 'function' && (<IDefaultValidator>object).isDefaultValidator === true;
+}

--- a/src/validators/validators.types.ts
+++ b/src/validators/validators.types.ts
@@ -42,8 +42,7 @@ export interface IFieldErrorObject {
  */
 // tslint:disable-next-line:no-any
 export function isIFieldErrorObject(object: any): object is IFieldErrorObject {
-  // tslint:disable-next-line:no-unsafe-any
-  return object && typeof object.message_id === 'string';
+  return object && typeof (<IFieldErrorObject>object).message_id === 'string';
 }
 
 /**


### PR DESCRIPTION
Enable users to tag their validators with `isDefaultValidator = true` so the form treats them as required validators.

Closes #21 