### PR TITLE
Added Form.busy for forcing the form into a busy state

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ### New features
 - Added prop `resetOnSubmit` to `Form`. When set to true, the form will trigger a form reset after a successful submit. Default setting: false
 - Added option for custom **required validators**. The form will now recognize a custom required validator if a synchronous validator is tagged with `isDefaultValidator = true`
+- Added prop `busy` to `Form`. This allows to force the form into a busy state. Useful for example to disable the form buttons during data loading.
 
 ## [2.0.0] # 2018-11-19
 ### Breaking changes

--- a/src/components/Form/Form.test.tsx
+++ b/src/components/Form/Form.test.tsx
@@ -498,6 +498,24 @@ describe('<Form />', () => {
         testBusyState(wrapper, formContext, false, done);
       });
 
+      describe('busy prop override set to true', () => {
+        it('should be always busy', () => {
+          const { formContext } = setup({ props: { busy: true }});
+          expect(formContext.busy).toBeTruthy();
+        });
+
+        it('should be busy if the onSubmit callback returns immediately', (done) => {
+          const onSubmitHandler = jest.fn();
+          const { wrapper, formContext } = setup({ props: { onSubmit: onSubmitHandler, busy: true }});
+          testBusyState(wrapper, formContext, true, done);
+        });
+
+        it('should be busy if there is no onSubmit callback', (done) => {
+          const { wrapper, formContext } = setup({ props: { busy: true }});
+          testBusyState(wrapper, formContext, true, done);
+        });
+      });
+
       describe('async onSubmit callback', () => {
         const createSlowOnSubmit = (): () => Promise<void> => {
           return async (): Promise<void> => new Promise<void>(
@@ -538,6 +556,20 @@ describe('<Form />', () => {
             wrapper.update();
             const formContext: IFormContext = wrapper.first().prop('value');
             expect(formContext.busy).toBe(false);
+            done();
+          });
+        });
+
+        it('should be busy after onSubmit finished if the busy prop is set to true', async (done) => {
+          const { wrapper } = setup({ props: { onSubmit: createSlowOnSubmit(), busy: true }});
+          await simulateSubmitEvent(wrapper);
+
+          jest.runAllTimers();
+
+          process.nextTick(() => {
+            wrapper.update();
+            const formContext: IFormContext = wrapper.first().prop('value');
+            expect(formContext.busy).toBe(true);
             done();
           });
         });

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -341,7 +341,11 @@ extends React.Component<IFormProps<TFieldValues, TSubmitArgs>, IFormState<TField
       formatString: stringFormatter,
       disabled,
       plaintext,
+      busy: busyProp,
     } = this.props;
+
+    // Override the busy state with the busy prop if it is set to true
+    const busy = busyProp === true ? busyProp : context.busy;
 
     return {
       ...context,
@@ -351,6 +355,7 @@ extends React.Component<IFormProps<TFieldValues, TSubmitArgs>, IFormState<TField
       stringFormatter,
       disabled,
       plaintext,
+      busy,
       asyncValidateOnChange: asyncValidateOnChange,
     };
   }

--- a/src/components/Form/Form.types.ts
+++ b/src/components/Form/Form.types.ts
@@ -58,6 +58,11 @@ export interface IFormProps<TFieldValues = IFieldValues, TSubmitArgs = unknown> 
    * If set to true, all fields will be reset on an successful form submit
    */
   resetOnSubmit?: boolean;
+  /**
+   * If set to true, the form will be forced into a busy state and thus disabling
+   * any form buttons.
+   */
+  busy?: true;
 
   /**
    * Triggered when the form has been validated successfully and is ready to be submitted.


### PR DESCRIPTION
### Summary
Added Form.busy for forcing the form into a busy state
Fixes #9 

### Checklist
Please ensure that you've fulfilled the following tasks:
* [X] My code follows the style guides of this project and `yarn lint` does not throw errors
* [X] My code is well tested and did not decrease the test coverage
* [X] All new and existing tests have passed
* [x] My submission passes the build
* [X] I've added changes to [CHANGELOG.MD](./CHANGELOG.MD)
* [ ] I've updated the project documentation
