### PR TITLE
Hotfix/validators.with param async

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 ### New features
 - Added `useFormContext` hook for easy access to the form context
+- Added `validators.withAsyncParam` wrapper function to call async validators with parameters
 
 ### Other
 - Migrated to react 16.8 to enable hooks functionality

--- a/src/validators/validators.test.ts
+++ b/src/validators/validators.test.ts
@@ -125,14 +125,18 @@ describe('default validators', () => {
     });
   });
 
-  describe('withParam utility', () => {
+  const withUtilityCases = [
+    ['withParam', validators.withParam],
+    ['withAsyncParam', validators.withAsyncParam],
+  ];
+  describe.each(withUtilityCases)('%s utility', (name: string, utility: ((first: Function, ...args: unknown[]) => Function)) => {
     const testValidator = jest.fn();
     const param1 = '123';
     const param2 = 456;
     const value = 'abcd';
     const context = createMockFormContext();
 
-    const func = validators.withParam(testValidator, param1, param2);
+    const func = utility(testValidator, param1, param2);
 
     it('should call the validator', () => {
       func(value, context);

--- a/src/validators/validators.ts
+++ b/src/validators/validators.ts
@@ -7,7 +7,7 @@
 
 import { IFormContext } from '../components/FormContext';
 import { TBasicFieldValue } from '../components/withField';
-import { FieldErrorMessageId, TAnyValidator, TFieldError } from './validators.types';
+import { FieldErrorMessageId, TAsyncValidator, TFieldError, TValidator } from './validators.types';
 
 /**
  * Wrapper function to call validators with parameters
@@ -15,8 +15,17 @@ import { FieldErrorMessageId, TAnyValidator, TFieldError } from './validators.ty
  * @param context form context
  * @param args parameters for the validator
  */
-const withParam = <TCallback extends TAnyValidator>(validator: TCallback, ...args: unknown[]): TAnyValidator => {
-  return (value: TBasicFieldValue, context: IFormContext): ReturnType<TAnyValidator> => validator(value, context, args);
+const withParam = (validator: TValidator, ...args: unknown[]): TValidator => {
+  return (value: TBasicFieldValue, context: IFormContext): TFieldError => validator(value, context, args);
+};
+/**
+ * Wrapper function to call async validators with parameters
+ * @param validator function to call
+ * @param context form context
+ * @param args parameters for the validator
+ */
+const withAsyncParam = (validator: TAsyncValidator, ...args: unknown[]): TAsyncValidator => {
+  return async (value: TBasicFieldValue, context: IFormContext): Promise<TFieldError> => validator(value, context, args);
 };
 
 /**
@@ -104,6 +113,7 @@ function isILength(object: any): object is ILength {
 // tslint:disable-next-line:naming-convention
 export const validators = {
   withParam,
+  withAsyncParam,
   required,
   alphaNumeric,
   minLength,

--- a/src/validators/validators.ts
+++ b/src/validators/validators.ts
@@ -7,7 +7,7 @@
 
 import { IFormContext } from '../components/FormContext';
 import { TBasicFieldValue } from '../components/withField';
-import { FieldErrorMessageId, TAsyncValidator, TFieldError, TValidator } from './validators.types';
+import { FieldErrorMessageId, TAnyValidator, TFieldError } from './validators.types';
 
 /**
  * Wrapper function to call validators with parameters
@@ -15,8 +15,8 @@ import { FieldErrorMessageId, TAsyncValidator, TFieldError, TValidator } from '.
  * @param context form context
  * @param args parameters for the validator
  */
-const withParam = <TCallback extends TValidator | TAsyncValidator>(validator: TCallback, ...args: unknown[]): TCallback => {
-  return (value: TBasicFieldValue, context: IFormContext): ReturnType<TCallback> => validator(value, context, args);
+const withParam = <TCallback extends TAnyValidator>(validator: TCallback, ...args: unknown[]): TAnyValidator => {
+  return (value: TBasicFieldValue, context: IFormContext): ReturnType<TAnyValidator> => validator(value, context, args);
 };
 
 /**

--- a/src/validators/validators.ts
+++ b/src/validators/validators.ts
@@ -7,7 +7,7 @@
 
 import { IFormContext } from '../components/FormContext';
 import { TBasicFieldValue } from '../components/withField';
-import { FieldErrorMessageId, TFieldError, TValidator } from './validators.types';
+import { FieldErrorMessageId, TAsyncValidator, TFieldError, TValidator } from './validators.types';
 
 /**
  * Wrapper function to call validators with parameters
@@ -15,8 +15,8 @@ import { FieldErrorMessageId, TFieldError, TValidator } from './validators.types
  * @param context form context
  * @param args parameters for the validator
  */
-const withParam = (validator: TValidator, ...args: unknown[]): TValidator => {
-  return (value: TBasicFieldValue, context: IFormContext): TFieldError => validator(value, context, args);
+const withParam = <TCallback extends TValidator | TAsyncValidator>(validator: TCallback, ...args: unknown[]): TCallback => {
+  return (value: TBasicFieldValue, context: IFormContext): ReturnType<TCallback> => validator(value, context, args);
 };
 
 /**

--- a/src/validators/validators.types.ts
+++ b/src/validators/validators.types.ts
@@ -62,12 +62,6 @@ export type TValidator = ((value: TBasicFieldValue, context: IFormContext, ...ar
  * Async validator method type
  */
 export type TAsyncValidator = ((value: TBasicFieldValue, context: IFormContext, ...args: unknown[]) => Promise<TFieldError>);
-/**
- * A validator that may be async or not
- */
-export type TAnyValidator = (
-  (value: TBasicFieldValue | undefined, context: IFormContext, ...args: unknown[]) => TFieldError | Promise<TFieldError>
-);
 
 /**
  * Default validator type

--- a/src/validators/validators.types.ts
+++ b/src/validators/validators.types.ts
@@ -62,6 +62,12 @@ export type TValidator = ((value: TBasicFieldValue, context: IFormContext, ...ar
  * Async validator method type
  */
 export type TAsyncValidator = ((value: TBasicFieldValue, context: IFormContext, ...args: unknown[]) => Promise<TFieldError>);
+/**
+ * A validator that may be async or not
+ */
+export type TAnyValidator = (
+  (value: TBasicFieldValue | undefined, context: IFormContext, ...args: unknown[]) => TFieldError | Promise<TFieldError>
+);
 
 /**
  * Default validator type


### PR DESCRIPTION
### Summary
Makes `validators.withParam` generic. Fixes #31 

### Checklist
Please ensure that you've fulfilled the following tasks:
* [x] My code follows the style guides of this project and `yarn lint` does not throw errors
* [x] My code is well tested and did not decrease the test coverage
* [x] All new and existing tests have passed
* [ ] My submission passes the build
* [x] I've added changes to [CHANGELOG.MD](./CHANGELOG.MD)
* [ ] I've updated the project documentation
