### PR TITLE
Added disabled and plaintext props to Field and FieldGroup

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ### New features
 - Added `useFormContext` hook for easy access to the form context
 - Added `validators.withAsyncParam` wrapper function to call async validators with parameters
+- Added `disabled` and `plaintext` props to `Field` to override global form state locally
 
 ### Other
 - Migrated to react 16.8 to enable hooks functionality

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 - Added `useFormContext` hook for easy access to the form context
 - Added `validators.withAsyncParam` wrapper function to call async validators with parameters
 - Added `disabled` and `plaintext` props to `Field` to override global form state locally
+- Added `disabled` and `plaintext` props to `FieldGroup` to override global form state locally
 
 ### Other
 - Migrated to react 16.8 to enable hooks functionality

--- a/src/components/FieldGroup/FieldGroup.test.tsx
+++ b/src/components/FieldGroup/FieldGroup.test.tsx
@@ -356,6 +356,39 @@ describe('<FieldGroup />', () => {
         });
       });
     });
+
+    const overrideCases = [
+      ['plaintext'],
+      ['disabled'],
+    ];
+
+    describe.each(overrideCases)('Context.%s behaviour', (prop) => {
+      const cases = [
+        [false, undefined, false],
+        [true, undefined, true],
+        [false, false, false],
+        [false, false, true],
+        [true, true, true],
+        [true, true, false],
+      ];
+
+      it.each(cases)(
+        `${prop} should be %s if Field.${prop} is %s and FormContext.${prop} is %s`,
+        (expectedValue: boolean, propValue: boolean | undefined, contextValue: boolean) => {
+          const { groupContext } = setup({
+            props: {
+              [prop]: propValue,
+            },
+            contextOverrides: {
+              [prop]: contextValue,
+            },
+          });
+
+          // @ts-ignore any is OK here
+          expect(groupContext[prop]).toEqual(expectedValue);
+        },
+      );
+    });
   });
 
   describe('render prop', () => {

--- a/src/components/FieldGroup/FieldGroup.tsx
+++ b/src/components/FieldGroup/FieldGroup.tsx
@@ -107,11 +107,13 @@ extends React.Component<IFieldGroupProps<TFieldValues>, IFieldGroupState> {
    * for the group items if needed
    */
   private getSubContext(): IFormContext {
-    const { context } = this.props;
+    const { context, disabled, plaintext } = this.props;
 
     return {
       ...context,
       ...this.state,
+      disabled: disabled === undefined ? context.disabled : disabled,
+      plaintext: plaintext === undefined ? context.plaintext : plaintext,
       defaultValues: this.overrideContextValues<IFieldValues>('defaultValues'),
       values: this.overrideContextValues<IFieldValues | undefined>('values'),
     };

--- a/src/components/FieldGroup/FieldGroup.types.ts
+++ b/src/components/FieldGroup/FieldGroup.types.ts
@@ -44,6 +44,14 @@ export interface IFieldGroupProps<TFieldValues = IFieldValues> extends IValidati
    */
   values?: TFieldValues;
   /**
+   * Disables this field group and all its fields.
+   */
+  disabled?: boolean;
+  /**
+   * Puts the field group and all its fields in plaintext mode.
+   */
+  plaintext?: boolean;
+  /**
    * Render prop
    * @param params Meta information about the group
    */

--- a/src/components/withField/Field/Field.types.ts
+++ b/src/components/withField/Field/Field.types.ts
@@ -67,6 +67,14 @@ export interface IBaseFieldProps {
    */
   getSubmitValue?: TValueCallback;
   /**
+   * Disables this field.
+   */
+  disabled?: boolean;
+  /**
+   * Puts the field in plaintext mode.
+   */
+  plaintext?: boolean;
+  /**
    * Triggered on field blur.
    */
   onBlur?(): void;


### PR DESCRIPTION
### Summary
* Adds `disabled` and `plaintext` props to `Field` and `FieldGroup` to override the global form state.
* Fixes #1 

### Checklist
Please ensure that you've fulfilled the following tasks:
* [x] My code follows the style guides of this project and `yarn lint` does not throw errors
* [x] My code is well tested and did not decrease the test coverage
* [x] All new and existing tests have passed
* [x] My submission passes the build
* [x] I've added changes to [CHANGELOG.MD](./CHANGELOG.MD)
* [ ] I've updated the project documentation
