### PR TITLE
Added exception if registerField is called with a name that has been already registered

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -13,6 +13,9 @@ All notable changes to this project will be documented in this file.
 - Added `useFormEventListener` hook for easy access to form events
 - Added `reset` to `FormContext`
 
+### Other
+- The `Form` will now throw an error if a duplicate field name is used.
+
 ## [2.2.0] # 2019-02-19
 ### New features
 - Added `useFormContext` hook for easy access to the form context

--- a/src/hooks/internal/__snapshots__/useFieldStates.test.ts.snap
+++ b/src/hooks/internal/__snapshots__/useFieldStates.test.ts.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`useFieldStates field registration and values registerField - field registration should throw an error if a field with the given name is already registered 1`] = `"[Form] registerField: Could not register field with name 'doubleField'. A field with this name already exists inside this form."`;
+
 exports[`useFieldStates invalid field registration case 1 of 5 props 1`] = `"[Form] registerField: invalid field state given"`;
 
 exports[`useFieldStates invalid field registration case 2 of 5 props 1`] = `"[Form] registerField: invalid field state given"`;

--- a/src/hooks/internal/useFieldStates.test.ts
+++ b/src/hooks/internal/useFieldStates.test.ts
@@ -89,6 +89,19 @@ describe('useFieldStates', () => {
           result.current.registerField(field.name, field.state);
         }).not.toThrowError();
       });
+
+      it('should throw an error if a field with the given name is already registered', () => {
+        const { result } = setup();
+
+        const mockName = 'doubleField';
+        const { state: mockState } = createMockField(mockName, mockName);
+
+        result.current.registerField(mockName, mockState);
+
+        expect(() => {
+          result.current.registerField(mockName, mockState);
+        }).toThrowErrorMatchingSnapshot();
+      });
     });
 
     describe('unregisterField - field cleanup', () => {

--- a/src/hooks/internal/useFieldStates.ts
+++ b/src/hooks/internal/useFieldStates.ts
@@ -83,6 +83,10 @@ export function useFieldStates(): IUseFieldStatesResult {
       throw new Error('[Form] registerField: invalid field state given');
     }
 
+    if (fields.current.has(name)) {
+      throw new Error(`[Form] registerField: Could not register field with name '${name}'. A field with this name already exists inside this form.`);
+    }
+
     fields.current.set(name, fieldState);
   }, []);
 


### PR DESCRIPTION
### Summary
This PR adds an exception if a field name is used twice inside a form. Previously dupcliate fields would result in a crash on form unmount.

Fixes #63 

### Checklist
Please ensure that you've fulfilled the following tasks:
* [x] My code follows the style guides of this project and `yarn lint` does not throw errors
* [x] My code is well tested and did not decrease the test coverage
* [x] All new and existing tests have passed
* [x] My submission passes the build
* [x] I've added changes to [CHANGELOG.MD](./CHANGELOG.MD)
* [ ] I've updated the project documentation
